### PR TITLE
Moving removeCoordinatorJob to avoid NullPointerException in running CoordinatorApp

### DIFF
--- a/src/main/scala/com/klout/scoozie/CoordinatorApp.scala
+++ b/src/main/scala/com/klout/scoozie/CoordinatorApp.scala
@@ -23,6 +23,8 @@ class CoordinatorApp[C: CanWriteXML, W: CanWriteXML](override val coordinator: C
 
   override val oozieClient: OozieClient = new OozieClient(oozieUrl)
 
+  ExecutionUtils.removeCoordinatorJob(coordinator.name, oozieClient)
+
   override val executionResult: Future[Job] =
     ExecutionUtils.run[OozieClient, Job, JobStatus](oozieClient, coordinator.getJobProperties(appPath, jobProperties))
 

--- a/src/main/scala/com/klout/scoozie/runner/CoordinatorAppAbs.scala
+++ b/src/main/scala/com/klout/scoozie/runner/CoordinatorAppAbs.scala
@@ -1,7 +1,6 @@
 package com.klout.scoozie.runner
 
 import com.klout.scoozie.dsl.Coordinator
-import com.klout.scoozie.utils.ExecutionUtils
 
 import scala.concurrent.Future
 import scalaxb.CanWriteXML
@@ -17,7 +16,6 @@ abstract class CoordinatorAppAbs[C: CanWriteXML, W: CanWriteXML] extends Scoozie
   lazy val writeResult = coordinator.writeJob(appPath, jobProperties, fileSystemUtils, postProcessing)
 
   logWriteResult()
-  ExecutionUtils.removeCoordinatorJob(coordinator.name, oozieClient)
 
   val executionResult: Future[Job]
 }

--- a/src/test/scala/com/klout/scoozie/runner/TestCoordinatorApp.scala
+++ b/src/test/scala/com/klout/scoozie/runner/TestCoordinatorApp.scala
@@ -18,6 +18,8 @@ class TestCoordinatorApp[C: CanWriteXML, W: CanWriteXML](override val coordinato
 
   import com.klout.scoozie.writer.implicits._
 
+  ExecutionUtils.removeCoordinatorJob(coordinator.name, oozieClient)
+
   override val executionResult: Future[Job] =
     ExecutionUtils.run[OozieClient, Job, JobStatus](oozieClient, coordinator.getJobProperties(appPath, jobProperties))
 }


### PR DESCRIPTION
I was using CoordinatorApp and received a NullPointerException at removeCoordinatorJob in CoordinatorAppAbs.  This is because removeCoordinatorJob(coordinator.name, oozieClient) in CoordinatorAppAbs is run before oozieClient is instantiated by CoordinatorApp.  Unfortunately, this bug was not picked up in the test suite becuase LocalOozie doesn't have a URL string, and therefore the test suite implements alternate TestCoordinatorApp that uses a provided OozieClient rather than override the base as per CoordinatorApp.  Not sure if there is a good way to test this and other Apps that have oozieUrl rather than oozieClient in the definition.